### PR TITLE
Preserve position and velocity validity on MechanismSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 - Initial public repository scaffold for The Allsparks FTC Team 36117.
 - Phase 0 `STALE` is documented and tested as observer liveness (gap since the previous `capture()` start), not Control Hub sample age. `staleAfterNanos <= 0` remains the default off switch ([#25](https://github.com/The-Allsparks/MIMIC/issues/25)).
+- `MechanismSnapshot` preserves position and velocity `SensorSample` validity so `STALE` is distinguishable from `MISSING` / `UNSUPPORTED`. Observation logs keep `pos` / `vel` and add `posValid` / `velValid` ([#26](https://github.com/The-Allsparks/MIMIC/issues/26)).
 - Source-backed mechanism-control research, build-versus-adopt decision, architecture, phased roadmap, and student documentation.
 - CI for compile, unit tests, and relative documentation link checks.
 

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -6,9 +6,9 @@ Living work-order for the orchestrator. Update after each issue or pull request.
 |-------|--------|
 | **Updated** | 2026-08-17 |
 | **Audited SHA** | `5847806f094f846cb3e8a4adf7ad0b355c4034fb` |
-| **Current implementation stream** | Draft [PR #1](https://github.com/The-Allsparks/MIMIC/pull/1) (`feature/phase-0-scaffold`) |
+| **Current implementation stream** | `feature/issue-26-snapshot-validity` from `main` (`70f1935`; PR #1 merged) |
 | **Automatic merge** | **false** — human approval required |
-| **Active subagent** | none until an issue is selected |
+| **Active subagent** | TA-C-GHill implementing #26 |
 | **Hardware available** | no (elevator not selected) |
 
 Full findings: [initial-deep-audit.md](initial-deep-audit.md). Roadmap: [#24](https://github.com/The-Allsparks/MIMIC/issues/24).
@@ -40,7 +40,7 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 | #5 Phase 0 abstraction | Foundation | Implemented in PR #1; C1 recorded as liveness | #4 | Open | — | same | #1 | Green | Pending #1 | Close on merge of #1 | Wait for #25 CI on PR #1 |
 | #7 Fake hardware | Foundation | Implemented in PR #1 | #5 | Open | — | same | #1 | Green | Pending #1 | Close on merge of #1 | Commented |
 | [#25](https://github.com/The-Allsparks/MIMIC/issues/25) Stale classification | HIGH correctness | Implemented locally | Phase 0 observer (PR #1) | Observer-liveness docs + tests on PR #1 | ended after implement | `feature/phase-0-scaffold` | #1 | Pending push | Not authorized | None | Push; wait for CI; human merge |
-| [#26](https://github.com/The-Allsparks/MIMIC/issues/26) Snapshot validity | MEDIUM architecture | Ready after or with #25 | #25 preferred | Not started | — | — | — | — | — | Prefer #25 first | Queue |
+| [#26](https://github.com/The-Allsparks/MIMIC/issues/26) Snapshot validity | MEDIUM architecture | Implemented locally | #25 closed | Implemented locally: position/velocity `SensorSample` on snapshot; `classifyPosition` STALE/MISSING/UNSUPPORTED | TA-C-GHill | `feature/issue-26-snapshot-validity` | — | — | Not authorized | None | Orchestrator commit; open PR to `main` |
 | [#27](https://github.com/The-Allsparks/MIMIC/issues/27) sensorValid velocity | MEDIUM correctness | Ready | #5 | Not started | — | — | — | — | — | None | After #25 |
 | [#28](https://github.com/The-Allsparks/MIMIC/issues/28) Missing limit logs | MEDIUM correctness | Ready | logger | Not started | — | — | — | — | — | None | After #25 |
 | [#29](https://github.com/The-Allsparks/MIMIC/issues/29) Phase 1 flag honesty | MEDIUM usability | Ready (Javadoc now) | #6 for full telemetry | Not started | — | — | — | — | — | Full Phase 1 needs hardware | After #25 |
@@ -56,12 +56,12 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 | Field | Value |
 |-------|--------|
-| **Selected** | [#25](https://github.com/The-Allsparks/MIMIC/issues/25) — Fix `MechanismObserver` stale classification and add tests |
-| **Status** | Implemented locally on `feature/phase-0-scaffold` (PR #1). Observer liveness documented and tested. Hub sample-age is **not** solved. CI pending. Not committed by the implementer. |
-| **Why highest priority** | Highest-severity **ready** correctness gap. Phase 0 `STALE` is now an honest liveness check with tests. Later actuation must not treat it as Hub health. |
-| **Dependencies** | Current observer on `feature/phase-0-scaffold` |
-| **Expected deliverable** | Correct freshness rule, unit tests, short doc note |
-| **Expected validation** | `./gradlew check` (local); CI on PR #1 after orchestrator commit |
+| **Selected** | [#26](https://github.com/The-Allsparks/MIMIC/issues/26) — Preserve position and velocity validity on `MechanismSnapshot` |
+| **Status** | Implemented locally on `feature/issue-26-snapshot-validity`. Not committed by the implementer. `#27` / `#28` not included. |
+| **Why highest priority** | Architectural seam: Phase 1 graphs need per-channel pose validity. `#25` closed so `STALE` is a real sample validity that the snapshot must keep. |
+| **Dependencies** | `#25` closed; `main` at `70f1935` |
+| **Expected deliverable** | `SensorSample` position/velocity on snapshot; validator uses sample validity; additive `posValid`/`velValid`; tests |
+| **Expected validation** | `./gradlew check` (local); CI on a new PR to `main` after orchestrator commit |
 | **Hardware required** | No |
 
 ## Stop conditions currently in effect
@@ -69,4 +69,4 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 - **Do not merge** without human approval (`AUTOMATIC_MERGE=false`).
 - **Do not enable** Phase 2–10 actuation.
 - **Do not invent** elevator hardware.
-- **Do not open** a second implementation PR while #1 is unresolved.
+- **Do not reopen** the merged Phase 0 branch (`feature/phase-0-scaffold`). New work targets `main`.

--- a/docs/mechanism-control/architecture.md
+++ b/docs/mechanism-control/architecture.md
@@ -57,6 +57,10 @@ Captures once per loop: position, velocity, acceleration estimate, commanded/app
 
 **Must not command hardware.**
 
+## `MechanismSnapshot`
+
+Immutable once-per-loop observation. Never used to write hardware. Position and velocity are `SensorSample`s (value, unit, and `MeasurementValidity`, including observer-liveness `STALE`). Scalar `position()` / `velocity()` delegate to the sample values. Absolute and redundant channels are also `SensorSample`s.
+
 ## `CalibrationManager` (Phase 2 — not implemented)
 
 Owns homing strategy, direction, max output, max travel, timeout, debounce, encoder reset policy, completion, invalidation.

--- a/docs/mechanism-control/testing.md
+++ b/docs/mechanism-control/testing.md
@@ -37,5 +37,5 @@ Each card requires: adult supervision, supports/restraints, exclusion zone, e-st
 1. Run `.\gradlew.bat test`.
 2. Export CSV from `MimicEventLogger` in a unit test.
 3. Graph `pos` vs time and mark a `SENSOR_INVALID` row.
-4. From `MechanismObserverTest.gapAboveThresholdMarksNumericSamplesStale`, explain why `STALE` is observer liveness (a slow `capture()` gap), not a frozen Hub encoder.
+4. From `MechanismObserverTest.gapAboveThresholdMarksNumericSamplesStale`, explain why `STALE` is observer liveness (a slow `capture()` gap), not a frozen Hub encoder. Mark a CSV row with `posValid=STALE` versus `MISSING`.
 5. Explain why `NO_ACTIVE_CONTROL` is the correct Phase 0 goal result.

--- a/src/main/java/org/allsparks/mimic/log/MimicEventLogger.java
+++ b/src/main/java/org/allsparks/mimic/log/MimicEventLogger.java
@@ -12,6 +12,9 @@ import org.allsparks.mimic.observe.MechanismSnapshot;
 /**
  * Records time-correlated mechanism events. Exportable for offline analysis.
  * Does not command hardware. Field names are TRACE-compatible (stable keys).
+ * Observation export keeps {@code pos} / {@code vel} and additively includes
+ * {@code posValid} / {@code velValid} as {@link org.allsparks.mimic.observe.MeasurementValidity}
+ * enum names.
  */
 public final class MimicEventLogger {
     private final int capacity;
@@ -40,8 +43,10 @@ public final class MimicEventLogger {
         Map<String, String> fields = new LinkedHashMap<>();
         fields.put("id", snapshot.mechanismId());
         fields.put("pos", format(snapshot.position()));
+        fields.put("posValid", snapshot.positionSample().validity().name());
         fields.put("unit", snapshot.positionUnitSymbol());
         fields.put("vel", format(snapshot.velocity()));
+        fields.put("velValid", snapshot.velocitySample().validity().name());
         fields.put("acc", format(snapshot.acceleration()));
         fields.put("reqOut", format(snapshot.requestedOutput()));
         fields.put("appOut", format(snapshot.appliedOutput()));

--- a/src/main/java/org/allsparks/mimic/observe/MechanismObserver.java
+++ b/src/main/java/org/allsparks/mimic/observe/MechanismObserver.java
@@ -95,8 +95,8 @@ public final class MechanismObserver {
         long duration = Math.max(0L, clock.nanoTime() - start);
         MechanismSnapshot snapshot = new MechanismSnapshot(
                 mechanismId,
-                position.value(),
-                velocity.value(),
+                position,
+                velocity,
                 acceleration,
                 units.canonicalUnitSymbol(),
                 requested,

--- a/src/main/java/org/allsparks/mimic/observe/MechanismSnapshot.java
+++ b/src/main/java/org/allsparks/mimic/observe/MechanismSnapshot.java
@@ -5,14 +5,17 @@ import java.util.Objects;
 /**
  * Immutable once-per-loop mechanism snapshot. Never used to write hardware.
  *
+ * Position and velocity are {@link SensorSample}s: value, unit, and
+ * {@link MeasurementValidity} (including observer-liveness {@code STALE}).
+ * {@link #position()} and {@link #velocity()} delegate to those samples.
  * Position, velocity, and acceleration share {@link #positionUnitSymbol()}.
  * Effort values are dimensionless in {@code [-1, 1]}. Current is amperes or
  * {@link Double#NaN} when unsupported.
  */
 public final class MechanismSnapshot {
     private final String mechanismId;
-    private final double position;
-    private final double velocity;
+    private final SensorSample positionSample;
+    private final SensorSample velocitySample;
     private final double acceleration;
     private final String positionUnitSymbol;
     private final double requestedOutput;
@@ -29,8 +32,8 @@ public final class MechanismSnapshot {
 
     public MechanismSnapshot(
             String mechanismId,
-            double position,
-            double velocity,
+            SensorSample positionSample,
+            SensorSample velocitySample,
             double acceleration,
             String positionUnitSymbol,
             double requestedOutput,
@@ -45,8 +48,8 @@ public final class MechanismSnapshot {
             long timestampNanos,
             long loopDurationNanos) {
         this.mechanismId = mechanismId == null ? "" : mechanismId;
-        this.position = position;
-        this.velocity = velocity;
+        this.positionSample = Objects.requireNonNull(positionSample, "positionSample");
+        this.velocitySample = Objects.requireNonNull(velocitySample, "velocitySample");
         this.acceleration = acceleration;
         this.positionUnitSymbol = positionUnitSymbol == null ? "" : positionUnitSymbol;
         this.requestedOutput = requestedOutput;
@@ -66,12 +69,22 @@ public final class MechanismSnapshot {
         return mechanismId;
     }
 
+    /** Canonical position; convenience delegate of {@link #positionSample()}. */
     public double position() {
-        return position;
+        return positionSample.value();
     }
 
+    /** Canonical velocity; convenience delegate of {@link #velocitySample()}. */
     public double velocity() {
-        return velocity;
+        return velocitySample.value();
+    }
+
+    public SensorSample positionSample() {
+        return positionSample;
+    }
+
+    public SensorSample velocitySample() {
+        return velocitySample;
     }
 
     public double acceleration() {

--- a/src/main/java/org/allsparks/mimic/observe/SnapshotValidator.java
+++ b/src/main/java/org/allsparks/mimic/observe/SnapshotValidator.java
@@ -4,32 +4,51 @@ package org.allsparks.mimic.observe;
  * Conservative checks on a snapshot. Does not command hardware.
  *
  * Missing or NaN measurements are classified; they are never replaced with
- * invented numbers.
+ * invented numbers. Position classification uses the position
+ * {@link SensorSample} validity (observer-liveness {@code STALE},
+ * {@code MISSING}, {@code UNSUPPORTED}) rather than reconstructing from
+ * {@link MechanismSnapshot#sensorValid()}.
  */
 public final class SnapshotValidator {
     private SnapshotValidator() {
     }
 
     public static boolean hasUsablePosition(MechanismSnapshot snapshot) {
-        return snapshot != null && snapshot.sensorValid() && !Double.isNaN(snapshot.position());
+        return snapshot != null && snapshot.positionSample().isUsable();
     }
 
     public static boolean effortIsFinite(double effort) {
         return !Double.isNaN(effort) && !Double.isInfinite(effort);
     }
 
+    /**
+     * Classifies the snapshot's primary position channel.
+     *
+     * Sample validity is returned first so {@link MeasurementValidity#STALE}
+     * is distinguishable from {@link MeasurementValidity#MISSING}. Snapshot
+     * disagreement is reported only when both encoders are usable and the
+     * observer already cleared {@link MechanismSnapshot#sensorValid()}
+     * (offset above threshold). Range is applied only when the sample is
+     * {@link MeasurementValidity#VALID}.
+     */
     public static MeasurementValidity classifyPosition(MechanismSnapshot snapshot, double min, double max) {
         if (snapshot == null) {
             return MeasurementValidity.MISSING;
         }
+        MeasurementValidity sampleValidity = snapshot.positionSample().validity();
+        if (sampleValidity != MeasurementValidity.VALID) {
+            return sampleValidity;
+        }
         if (Double.isNaN(snapshot.position())) {
             return MeasurementValidity.MISSING;
         }
-        if (!snapshot.sensorValid()) {
-            if (!Double.isNaN(snapshot.disagreement()) && snapshot.disagreement() > 0.0) {
-                return MeasurementValidity.DISAGREEING;
-            }
-            return MeasurementValidity.MISSING;
+        // Disagreement is snapshot-level: both encoders usable and the observer
+        // already invalidated the aggregate (offset above threshold). A nonzero
+        // offset below the threshold must not be classified as DISAGREEING.
+        if (!snapshot.sensorValid()
+                && snapshot.velocitySample().isUsable()
+                && snapshot.redundantPosition().isUsable()) {
+            return MeasurementValidity.DISAGREEING;
         }
         if (snapshot.position() < min || snapshot.position() > max) {
             return MeasurementValidity.OUT_OF_RANGE;

--- a/src/test/java/org/allsparks/mimic/MimicSessionTest.java
+++ b/src/test/java/org/allsparks/mimic/MimicSessionTest.java
@@ -65,6 +65,8 @@ class MimicSessionTest {
         assertFalse(snapshot.upperLimit().asserted());
         assertEquals("mm", snapshot.positionUnitSymbol());
         assertTrue(session.logger().exportCsv().contains("pos="));
+        assertTrue(session.logger().exportCsv().contains("posValid=VALID"));
+        assertTrue(session.logger().exportCsv().contains("velValid=VALID"));
     }
 
     @Test

--- a/src/test/java/org/allsparks/mimic/observe/MechanismObserverTest.java
+++ b/src/test/java/org/allsparks/mimic/observe/MechanismObserverTest.java
@@ -47,6 +47,9 @@ class MechanismObserverTest {
         MechanismSnapshot snapshot = observer.capture();
         assertFalse(snapshot.sensorValid());
         assertTrue(Double.isNaN(snapshot.position()));
+        assertEquals(MeasurementValidity.MISSING, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.MISSING,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
         assertFalse(SnapshotValidator.hasUsablePosition(snapshot));
     }
 
@@ -68,10 +71,10 @@ class MechanismObserverTest {
     void staleCheckDisabledByDefaultDoesNotMarkStale() {
         AtomicLong time = new AtomicLong(1_000_000L);
         MechanismObserver observer = livenessObserver(time, 0L);
-        assertEquals(MeasurementValidity.VALID, observer.capture().absoluteSensor().validity());
+        assertPrimaryChannels(observer.capture(), MeasurementValidity.VALID);
         time.addAndGet(5_000_000_000L);
         MechanismSnapshot snapshot = observer.capture();
-        assertEquals(MeasurementValidity.VALID, snapshot.absoluteSensor().validity());
+        assertPrimaryChannels(snapshot, MeasurementValidity.VALID);
         assertTrue(snapshot.sensorValid());
     }
 
@@ -82,7 +85,7 @@ class MechanismObserverTest {
         observer.capture();
         time.addAndGet(5_000_000_000L);
         MechanismSnapshot snapshot = observer.capture();
-        assertEquals(MeasurementValidity.VALID, snapshot.absoluteSensor().validity());
+        assertPrimaryChannels(snapshot, MeasurementValidity.VALID);
         assertTrue(snapshot.sensorValid());
     }
 
@@ -91,7 +94,7 @@ class MechanismObserverTest {
         AtomicLong time = new AtomicLong(9_000_000_000L);
         MechanismObserver observer = livenessObserver(time, 50_000_000L);
         MechanismSnapshot snapshot = observer.capture();
-        assertEquals(MeasurementValidity.VALID, snapshot.absoluteSensor().validity());
+        assertPrimaryChannels(snapshot, MeasurementValidity.VALID);
         assertTrue(snapshot.sensorValid());
     }
 
@@ -102,7 +105,9 @@ class MechanismObserverTest {
         observer.capture();
         time.addAndGet(50_000_001L);
         MechanismSnapshot snapshot = observer.capture();
-        assertEquals(MeasurementValidity.STALE, snapshot.absoluteSensor().validity());
+        assertPrimaryChannels(snapshot, MeasurementValidity.STALE);
+        assertEquals(MeasurementValidity.STALE,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
         assertEquals(12.5, snapshot.absoluteSensor().value(), 1e-9);
         assertFalse(snapshot.sensorValid());
     }
@@ -114,7 +119,7 @@ class MechanismObserverTest {
         observer.capture();
         time.addAndGet(50_000_000L);
         MechanismSnapshot snapshot = observer.capture();
-        assertEquals(MeasurementValidity.VALID, snapshot.absoluteSensor().validity());
+        assertPrimaryChannels(snapshot, MeasurementValidity.VALID);
         assertTrue(snapshot.sensorValid());
     }
 
@@ -125,7 +130,7 @@ class MechanismObserverTest {
         observer.capture();
         time.addAndGet(49_999_999L);
         MechanismSnapshot snapshot = observer.capture();
-        assertEquals(MeasurementValidity.VALID, snapshot.absoluteSensor().validity());
+        assertPrimaryChannels(snapshot, MeasurementValidity.VALID);
         assertTrue(snapshot.sensorValid());
     }
 
@@ -135,10 +140,10 @@ class MechanismObserverTest {
         MechanismObserver observer = livenessObserver(time, 50_000_000L);
         observer.capture();
         time.addAndGet(50_000_001L);
-        assertEquals(MeasurementValidity.STALE, observer.capture().absoluteSensor().validity());
+        assertPrimaryChannels(observer.capture(), MeasurementValidity.STALE);
         time.addAndGet(1_000_000L);
         MechanismSnapshot recovered = observer.capture();
-        assertEquals(MeasurementValidity.VALID, recovered.absoluteSensor().validity());
+        assertPrimaryChannels(recovered, MeasurementValidity.VALID);
         assertTrue(recovered.sensorValid());
     }
 
@@ -150,8 +155,14 @@ class MechanismObserverTest {
         time.addAndGet(20_000_000L);
         MechanismSnapshot second = observer.capture();
         assertEquals(first.absoluteSensor().value(), second.absoluteSensor().value(), 1e-9);
-        assertEquals(MeasurementValidity.VALID, second.absoluteSensor().validity());
+        assertPrimaryChannels(second, MeasurementValidity.VALID);
         assertTrue(second.sensorValid());
+    }
+
+    private static void assertPrimaryChannels(MechanismSnapshot snapshot, MeasurementValidity expected) {
+        assertEquals(expected, snapshot.positionSample().validity());
+        assertEquals(expected, snapshot.velocitySample().validity());
+        assertEquals(expected, snapshot.absoluteSensor().validity());
     }
 
     private static MechanismObserver livenessObserver(AtomicLong time, long staleAfterNanos) {

--- a/src/test/java/org/allsparks/mimic/observe/SnapshotValidatorTest.java
+++ b/src/test/java/org/allsparks/mimic/observe/SnapshotValidatorTest.java
@@ -1,0 +1,167 @@
+package org.allsparks.mimic.observe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.allsparks.mimic.units.DirectionSign;
+import org.allsparks.mimic.units.MechanismUnits;
+import org.junit.jupiter.api.Test;
+
+class SnapshotValidatorTest {
+
+    @Test
+    void classifyPositionReportsStaleFromPositionSample() {
+        AtomicLong time = new AtomicLong(1_000_000L);
+        MechanismObserver observer = livenessObserver(time);
+        observer.capture();
+        time.addAndGet(50_000_001L);
+        MechanismSnapshot snapshot = observer.capture();
+        assertEquals(MeasurementValidity.STALE, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.STALE,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+        assertFalse(SnapshotValidator.hasUsablePosition(snapshot));
+    }
+
+    @Test
+    void classifyPositionDistinguishesStaleFromMissing() {
+        AtomicLong time = new AtomicLong(1_000_000L);
+        MechanismObserver staleObserver = livenessObserver(time);
+        staleObserver.capture();
+        time.addAndGet(50_000_001L);
+        MeasurementValidity stale = SnapshotValidator.classifyPosition(
+                staleObserver.capture(), -1000.0, 1000.0);
+
+        MechanismSnapshot missing = MechanismObserver.builder(
+                        "arm",
+                        () -> 10L,
+                        MechanismUnits.rotaryRadians("arm", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> Double.NaN)
+                .ticksPerSecond(() -> 0.0)
+                .build()
+                .capture();
+
+        assertEquals(MeasurementValidity.STALE, stale);
+        assertEquals(MeasurementValidity.MISSING, missing.positionSample().validity());
+        assertEquals(MeasurementValidity.MISSING,
+                SnapshotValidator.classifyPosition(missing, -1000.0, 1000.0));
+        assertNotEquals(stale, SnapshotValidator.classifyPosition(missing, -1000.0, 1000.0));
+    }
+
+    @Test
+    void classifyPositionReportsUnsupportedWhenTicksOmitted() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "intake",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("intake", 1.0, DirectionSign.POSITIVE))
+                .ticksPerSecond(() -> 0.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.UNSUPPORTED,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+        assertFalse(SnapshotValidator.hasUsablePosition(snapshot));
+    }
+
+    @Test
+    void classifyPositionReportsMissingOnNaNTicks() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "arm",
+                        () -> 10L,
+                        MechanismUnits.rotaryRadians("arm", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> Double.NaN)
+                .ticksPerSecond(() -> 0.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.MISSING, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.MISSING,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+        assertFalse(SnapshotValidator.hasUsablePosition(snapshot));
+    }
+
+    @Test
+    void classifyPositionReportsDisagreeingWhenRedundantOffset() {
+        AtomicReference<Double> primary = new AtomicReference<>(100.0);
+        AtomicReference<Double> redundant = new AtomicReference<>(160.0);
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 1_000L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(primary::get)
+                .ticksPerSecond(() -> 0.0)
+                .redundantTicks(redundant::get)
+                .disagreementThreshold(10.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.DISAGREEING,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+    }
+
+    @Test
+    void classifyPositionIgnoresSubThresholdDisagreement() {
+        AtomicReference<Double> primary = new AtomicReference<>(100.0);
+        AtomicReference<Double> redundant = new AtomicReference<>(105.0);
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 1_000L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(primary::get)
+                .ticksPerSecond(() -> 0.0)
+                .redundantTicks(redundant::get)
+                .disagreementThreshold(10.0)
+                .build()
+                .capture();
+        assertEquals(5.0, snapshot.disagreement(), 1e-9);
+        assertTrue(snapshot.sensorValid());
+        assertEquals(MeasurementValidity.VALID,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+    }
+
+    @Test
+    void classifyPositionReportsOutOfRange() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 500.0)
+                .ticksPerSecond(() -> 0.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.OUT_OF_RANGE,
+                SnapshotValidator.classifyPosition(snapshot, -10.0, 10.0));
+        assertTrue(SnapshotValidator.hasUsablePosition(snapshot));
+    }
+
+    @Test
+    void hasUsablePositionFollowsPositionSampleNotAggregateSensorValid() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 100.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+        assertTrue(SnapshotValidator.hasUsablePosition(snapshot));
+        assertEquals(MeasurementValidity.VALID,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+    }
+
+    private static MechanismObserver livenessObserver(AtomicLong time) {
+        return MechanismObserver.builder(
+                        "elev",
+                        time::get,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 100.0)
+                .ticksPerSecond(() -> 0.0)
+                .staleAfterNanos(50_000_000L)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Preserve per-channel position and velocity validity on `MechanismSnapshot` so Phase 0 can distinguish `STALE` from `MISSING` and `UNSUPPORTED` on the primary pose.

## Problem

`MechanismObserver` already built `SensorSample`s for position and velocity, then stored only doubles. `SnapshotValidator.classifyPosition` guessed `MISSING` whenever `sensorValid` was false (unless disagreement). After #25, `STALE` existed but could not be reported on the primary pose.

## Solution

- Store `SensorSample positionSample` and `velocitySample` on the snapshot.
- Keep `position()` / `velocity()` as value delegates.
- Classify from the position sample first; report `DISAGREEING` only when both encoders are usable and the observer already cleared `sensorValid` (offset above threshold, not any nonzero delta).
- Add additive log keys `posValid` / `velValid` (enum names).

## Scope

Issue #26 snapshot schema seam, validator, tests, additive logger keys, architecture/testing docs.

## Out of scope

- #27 `sensorValid` still requiring unused velocity
- #28 missing limits logged as `asserted=false`
- Hub sample-age, actuation, hardware

## Architecture impact

Snapshots now match absolute/redundant channels: per-channel value + validity. Constructor arity changes for any out-of-tree `new MechanismSnapshot(...)`. In-repo, only `MechanismObserver.capture()` constructs snapshots.

## Safety impact

No motor or servo writes. Does not invent values. `STALE` remains observer liveness, not Hub health.

## Compatibility impact

Scalar accessors remain. CSV `pos` / `vel` remain. New keys are additive. `hasUsablePosition` now follows the position sample, so a position-only observer can have a usable pose while `sensorValid` stays false (#27 boundary).

## Tests

- New `SnapshotValidatorTest` (STALE vs MISSING vs UNSUPPORTED, disagreement above and below threshold, OUT_OF_RANGE, position-only usable pose)
- `MechanismObserverTest` asserts `positionSample` / `velocitySample` on liveness cases
- `MimicSessionTest` asserts `posValid=VALID`

## Validation results

Desktop unit tests were run successfully on this branch before a later Gradle daemon stall. CI on this PR is the confirmation gate for the disagreement-threshold classifier fix.

## Hardware validation

Not performed. Not required.

## Documentation

`architecture.md` snapshot bullet, validator/logger Javadoc, `testing.md` student exercise, CHANGELOG, priority ledger.

## Risks

Out-of-tree snapshot constructors break. CSV parsers that assumed only `pos=` still work. Students must not treat `posValid=STALE` as encoder-disconnected.

## Rollback or disable strategy

Revert this PR. Scalar accessors on `main` today remain the public shape as delegates after landing.

## Known limitations

`sensorValid` still requires velocity (#27). Limit CSV validity is still #28.

## Related issue

Closes #26
Part of #24
