### PR TITLE
Treat omitted velocity as optional for sensorValid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Source-backed mechanism-control research, build-versus-adopt decision, architecture, phased roadmap, and student documentation.
 - CI for compile, unit tests, and relative documentation link checks.
 
+### Changed
+
+- `sensorValid` means required wired channels are usable and not disagreeing. Velocity is required only when `ticksPerSecond` is wired (`UNSUPPORTED` velocity does not clear the flag). Analog-only observation wires mapped analog as `ticks`; omitted ticks still keeps the snapshot invalid ([#27](https://github.com/The-Allsparks/MIMIC/issues/27)).
+
 ### Safety
 
 - All motor and servo output features remain disabled by default.

--- a/docs/audits/initial-deep-audit.md
+++ b/docs/audits/initial-deep-audit.md
@@ -162,6 +162,8 @@ A position-only mechanism (potentiometer, analog absolute encoder, some servos) 
 
 **Evidence:** `MechanismObserver.capture()`; `RevAnalogSensorObserver` exists for exactly this hardware.
 
+**Status (#27):** `sensorValid` is usable primary pose, `UNSUPPORTED` or usable velocity, and no disagreement. Omitted `ticksPerSecond` no longer clears the flag. Omitted `ticks` still does. Analog-only observation wires the mapped analog value as `ticks`; `absoluteSensor` is not a substitute primary pose. `classifyPosition` reports `DISAGREEING` for position-only redundant offset; wired `MISSING`/`STALE` velocity is not treated as disagreement.
+
 ### C3 — Missing limit switches log as not asserted — MEDIUM / CORRECTNESS
 
 `LimitSwitchSample.missing()` sets `asserted = false`. `MimicEventLogger.recordObservation` logs `Boolean.toString(snapshot.lowerLimit().asserted())` without validity. A disconnected switch is exported as `lower=false`.
@@ -394,7 +396,7 @@ MIMIC is ready to be a **teaching and observation scaffold** after PR #1 is acce
 | R1 | HIGH | SECURITY | Human decision | [#31](https://github.com/The-Allsparks/MIMIC/issues/31) |
 | S3 | HIGH | SAFETY | Process | #31 + CONTRIBUTING |
 | A1 | MEDIUM | ARCHITECTURE | Yes after C1 or parallel | [#26](https://github.com/The-Allsparks/MIMIC/issues/26) |
-| C2 | MEDIUM | CORRECTNESS | Yes | [#27](https://github.com/The-Allsparks/MIMIC/issues/27) |
+| C2 | MEDIUM | CORRECTNESS | Implemented locally (#27) | [#27](https://github.com/The-Allsparks/MIMIC/issues/27) |
 | C3 | MEDIUM | CORRECTNESS | Yes | [#28](https://github.com/The-Allsparks/MIMIC/issues/28) |
 | U1 / D2 | MEDIUM | USABILITY | Yes | [#29](https://github.com/The-Allsparks/MIMIC/issues/29); full telemetry #6 |
 | P1 | MEDIUM | PERFORMANCE | Research | [#32](https://github.com/The-Allsparks/MIMIC/issues/32) |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -6,9 +6,9 @@ Living work-order for the orchestrator. Update after each issue or pull request.
 |-------|--------|
 | **Updated** | 2026-08-17 |
 | **Audited SHA** | `5847806f094f846cb3e8a4adf7ad0b355c4034fb` |
-| **Current implementation stream** | `feature/issue-26-snapshot-validity` from `main` (`70f1935`; PR #1 merged) |
+| **Current implementation stream** | `feature/issue-27-sensor-valid` from `main` (`ae2f17e`; PR #40 / #26 merged) |
 | **Automatic merge** | **false** — human approval required |
-| **Active subagent** | TA-C-GHill implementing #26 |
+| **Active subagent** | implementing #27 |
 | **Hardware available** | no (elevator not selected) |
 
 Full findings: [initial-deep-audit.md](initial-deep-audit.md). Roadmap: [#24](https://github.com/The-Allsparks/MIMIC/issues/24).
@@ -40,8 +40,8 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 | #5 Phase 0 abstraction | Foundation | Implemented in PR #1; C1 recorded as liveness | #4 | Open | — | same | #1 | Green | Pending #1 | Close on merge of #1 | Wait for #25 CI on PR #1 |
 | #7 Fake hardware | Foundation | Implemented in PR #1 | #5 | Open | — | same | #1 | Green | Pending #1 | Close on merge of #1 | Commented |
 | [#25](https://github.com/The-Allsparks/MIMIC/issues/25) Stale classification | HIGH correctness | Implemented locally | Phase 0 observer (PR #1) | Observer-liveness docs + tests on PR #1 | ended after implement | `feature/phase-0-scaffold` | #1 | Pending push | Not authorized | None | Push; wait for CI; human merge |
-| [#26](https://github.com/The-Allsparks/MIMIC/issues/26) Snapshot validity | MEDIUM architecture | Implemented locally | #25 closed | Implemented locally: position/velocity `SensorSample` on snapshot; `classifyPosition` STALE/MISSING/UNSUPPORTED | TA-C-GHill | `feature/issue-26-snapshot-validity` | — | — | Not authorized | None | Orchestrator commit; open PR to `main` |
-| [#27](https://github.com/The-Allsparks/MIMIC/issues/27) sensorValid velocity | MEDIUM correctness | Ready | #5 | Not started | — | — | — | — | — | None | After #25 |
+| [#26](https://github.com/The-Allsparks/MIMIC/issues/26) Snapshot validity | MEDIUM architecture | Done | #25 closed | Merged on `main` via [PR #40](https://github.com/The-Allsparks/MIMIC/pull/40) (`ae2f17e`) | — | `feature/issue-26-snapshot-validity` | [#40](https://github.com/The-Allsparks/MIMIC/pull/40) | Green | Merged | None | Closed with #40 |
+| [#27](https://github.com/The-Allsparks/MIMIC/issues/27) sensorValid velocity | MEDIUM correctness | Implemented locally | #26 merged | Position-only `sensorValid`; `UNSUPPORTED` velocity does not clear; analog-as-`ticks`; `classifyPosition` disagreement without requiring usable velocity | — | `feature/issue-27-sensor-valid` | — | — | Not authorized | None | Orchestrator commit; open PR to `main` |
 | [#28](https://github.com/The-Allsparks/MIMIC/issues/28) Missing limit logs | MEDIUM correctness | Ready | logger | Not started | — | — | — | — | — | None | After #25 |
 | [#29](https://github.com/The-Allsparks/MIMIC/issues/29) Phase 1 flag honesty | MEDIUM usability | Ready (Javadoc now) | #6 for full telemetry | Not started | — | — | — | — | — | Full Phase 1 needs hardware | After #25 |
 | [#30](https://github.com/The-Allsparks/MIMIC/issues/30) Pin Actions SHAs | MEDIUM security | Ready | — | Not started | — | — | — | — | — | None | After correctness slices |
@@ -56,11 +56,11 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 | Field | Value |
 |-------|--------|
-| **Selected** | [#26](https://github.com/The-Allsparks/MIMIC/issues/26) — Preserve position and velocity validity on `MechanismSnapshot` |
-| **Status** | Implemented locally on `feature/issue-26-snapshot-validity`. Not committed by the implementer. `#27` / `#28` not included. |
-| **Why highest priority** | Architectural seam: Phase 1 graphs need per-channel pose validity. `#25` closed so `STALE` is a real sample validity that the snapshot must keep. |
-| **Dependencies** | `#25` closed; `main` at `70f1935` |
-| **Expected deliverable** | `SensorSample` position/velocity on snapshot; validator uses sample validity; additive `posValid`/`velValid`; tests |
+| **Selected** | [#27](https://github.com/The-Allsparks/MIMIC/issues/27) — Do not require unused velocity for `sensorValid` |
+| **Status** | Implemented locally on `feature/issue-27-sensor-valid`. Not committed by the implementer. `#28` not included. |
+| **Why highest priority** | C2 correctness: position-only / analog observers must not look permanently failed. `#26` merged so per-channel validity is on the snapshot. |
+| **Dependencies** | `#26` merged; `main` at `ae2f17e` |
+| **Expected deliverable** | `sensorValid` = usable pose and (`UNSUPPORTED` or usable velocity) and not disagreeing; analog-as-`ticks`; tests; docs |
 | **Expected validation** | `./gradlew check` (local); CI on a new PR to `main` after orchestrator commit |
 | **Hardware required** | No |
 

--- a/docs/mechanism-control/architecture.md
+++ b/docs/mechanism-control/architecture.md
@@ -55,6 +55,8 @@ Phase 0/1 stop after snapshot + log. Team code still owns `setPower`.
 
 Captures once per loop: position, velocity, acceleration estimate, commanded/applied output, current where available, limits, absolute sensor, calibration observation, freshness, loop timing, redundant disagreement.
 
+`sensorValid` is aggregate health of **required wired channels**, not “every channel exists.” Primary pose is required (omitted `ticks` keeps it false). Velocity is required only if `ticksPerSecond` is wired; `UNSUPPORTED` velocity does not clear the flag. Analog-only mechanisms wire the mapped analog value as `ticks` and omit velocity; `absoluteSensor` is an optional extra channel, not a substitute primary pose.
+
 **Must not command hardware.**
 
 ## `MechanismSnapshot`

--- a/docs/mechanism-control/glossary.md
+++ b/docs/mechanism-control/glossary.md
@@ -26,6 +26,7 @@
 | **Synchronization** | Keeping multiple actuators consistent. |
 | **Anti-racking** | Preventing structural twist from side-to-side disagreement. |
 | **Degraded operation** | Reduced capability while remaining as safe as possible. |
+| **sensorValid** | Aggregate: required wired channels usable and not disagreeing. Primary pose is required (omitted `ticks` keeps it false). Velocity is required only if `ticksPerSecond` is wired. |
 | **STALE** | Observer not called within `staleAfterNanos` (loop-call gap). Not Hub sample age and not “encoder disconnected.” Frozen supplier values on a timely loop stay `VALID`. |
 
 Student exercise: pick three terms and give an elevator example for each.

--- a/docs/mechanism-control/troubleshooting.md
+++ b/docs/mechanism-control/troubleshooting.md
@@ -6,6 +6,9 @@
 | Position sign wrong | `DirectionSign` or motor invert mismatch | Fix mapping; re-record |
 | `MISSING` limit | Supplier threw (disconnected) | Check DIO wiring; NC vs NO |
 | `UNSUPPORTED` current | No current supplier wired | Optional; measure overhead before adding |
+| `UNSUPPORTED` velocity | No `ticksPerSecond` supplier wired | Optional; a position-only observer can still be `sensorValid` |
+| `UNSUPPORTED` position / omitted ticks | No `.ticks(...)` supplier | Primary pose is required; snapshot stays invalid |
+| Analog-only looks `sensorValid=false` | Analog wired only as `absoluteSensor` | Wire the mapped analog value as `.ticks(...)` and omit `.ticksPerSecond(...)`; `absoluteSensor` is a second channel |
 | Disagreement invalidates snapshot | Redundant encoder offset or one side slipping | Do not average blindly |
 | Loop time high | `getCurrent` on many motors | Poll slower ([GM0](https://gm0.org/en/latest/docs/software/adv-control-system/sdk-motors.html)) |
 | Goal always rejected | Phase 0 `NO_ACTIVE_CONTROL` | Expected |

--- a/src/main/java/org/allsparks/mimic/observe/MechanismObserver.java
+++ b/src/main/java/org/allsparks/mimic/observe/MechanismObserver.java
@@ -72,7 +72,21 @@ public final class MechanismObserver {
         return new Builder(mechanismId, clock, units);
     }
 
-    /** Read sensors once and return an immutable snapshot. Does not write hardware. */
+    /**
+     * Read sensors once and return an immutable snapshot. Does not write hardware.
+     *
+     * {@link MechanismSnapshot#sensorValid()} is true when required wired
+     * channels are usable and redundant encoders are not disagreeing. Primary
+     * position is required: omitted {@code ticks} is
+     * {@link MeasurementValidity#UNSUPPORTED} and keeps the flag false.
+     * Velocity is required only when {@code ticksPerSecond} is wired;
+     * {@code UNSUPPORTED} velocity does not clear the flag. Wired but
+     * {@code MISSING}, {@code STALE}, NaN, or throwing velocity still does.
+     * Analog-only mechanisms wire the mapped analog value as {@code ticks}
+     * and omit {@code ticksPerSecond}; {@code absoluteSensor} is an optional
+     * extra channel, not a substitute primary pose. Velocity is never
+     * inferred from position.
+     */
     public MechanismSnapshot capture() {
         long start = clock.nanoTime();
         SensorSample position = readPosition(start);
@@ -91,7 +105,11 @@ public final class MechanismObserver {
             disagreement = Math.abs(position.value() - redundant.value());
             disagreeing = disagreement > disagreementThreshold;
         }
-        boolean sensorValid = position.isUsable() && velocity.isUsable() && !disagreeing;
+        boolean sensorValid =
+                position.isUsable()
+                        && (velocity.validity() == MeasurementValidity.UNSUPPORTED
+                                || velocity.isUsable())
+                        && !disagreeing;
         long duration = Math.max(0L, clock.nanoTime() - start);
         MechanismSnapshot snapshot = new MechanismSnapshot(
                 mechanismId,

--- a/src/main/java/org/allsparks/mimic/observe/MechanismSnapshot.java
+++ b/src/main/java/org/allsparks/mimic/observe/MechanismSnapshot.java
@@ -123,6 +123,15 @@ public final class MechanismSnapshot {
         return redundantPosition;
     }
 
+    /**
+     * Aggregate health of required wired channels, not “every channel exists.”
+     *
+     * True when primary position is usable, velocity is either
+     * {@link MeasurementValidity#UNSUPPORTED} or usable, and redundant
+     * encoders are not disagreeing. Omitted {@code ticks} keeps this false.
+     * {@link #absoluteSensor()} is optional and does not substitute for
+     * primary pose.
+     */
     public boolean sensorValid() {
         return sensorValid;
     }

--- a/src/main/java/org/allsparks/mimic/observe/SnapshotValidator.java
+++ b/src/main/java/org/allsparks/mimic/observe/SnapshotValidator.java
@@ -26,9 +26,11 @@ public final class SnapshotValidator {
      *
      * Sample validity is returned first so {@link MeasurementValidity#STALE}
      * is distinguishable from {@link MeasurementValidity#MISSING}. Snapshot
-     * disagreement is reported only when both encoders are usable and the
-     * observer already cleared {@link MechanismSnapshot#sensorValid()}
-     * (offset above threshold). Range is applied only when the sample is
+     * disagreement is reported only when both encoders are usable, velocity is
+     * {@link MeasurementValidity#UNSUPPORTED} or usable, and the observer
+     * already cleared {@link MechanismSnapshot#sensorValid()} (offset above
+     * threshold). Wired {@code MISSING} or {@code STALE} velocity is not
+     * classified as disagreement. Range is applied only when the sample is
      * {@link MeasurementValidity#VALID}.
      */
     public static MeasurementValidity classifyPosition(MechanismSnapshot snapshot, double min, double max) {
@@ -45,8 +47,10 @@ public final class SnapshotValidator {
         // Disagreement is snapshot-level: both encoders usable and the observer
         // already invalidated the aggregate (offset above threshold). A nonzero
         // offset below the threshold must not be classified as DISAGREEING.
+        // UNSUPPORTED velocity is optional and does not explain a false
+        // sensorValid; MISSING/STALE velocity does, so those are not DISAGREEING.
         if (!snapshot.sensorValid()
-                && snapshot.velocitySample().isUsable()
+                && velocityOptionalOrUsable(snapshot)
                 && snapshot.redundantPosition().isUsable()) {
             return MeasurementValidity.DISAGREEING;
         }
@@ -54,5 +58,16 @@ public final class SnapshotValidator {
             return MeasurementValidity.OUT_OF_RANGE;
         }
         return MeasurementValidity.VALID;
+    }
+
+    /**
+     * {@link MeasurementValidity#UNSUPPORTED} velocity is not required for
+     * aggregate health. Wired {@code MISSING} or {@code STALE} velocity still
+     * clears {@link MechanismSnapshot#sensorValid()} on its own, so it must
+     * not be classified as encoder disagreement.
+     */
+    private static boolean velocityOptionalOrUsable(MechanismSnapshot snapshot) {
+        return snapshot.velocitySample().validity() == MeasurementValidity.UNSUPPORTED
+                || snapshot.velocitySample().isUsable();
     }
 }

--- a/src/test/java/org/allsparks/mimic/observe/MechanismObserverTest.java
+++ b/src/test/java/org/allsparks/mimic/observe/MechanismObserverTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.allsparks.mimic.adapters.rev.RevAnalogSensorObserver;
 import org.allsparks.mimic.clock.MimicClock;
 import org.allsparks.mimic.units.DirectionSign;
 import org.allsparks.mimic.units.MechanismUnits;
@@ -157,6 +158,126 @@ class MechanismObserverTest {
         assertEquals(first.absoluteSensor().value(), second.absoluteSensor().value(), 1e-9);
         assertPrimaryChannels(second, MeasurementValidity.VALID);
         assertTrue(second.sensorValid());
+    }
+
+    @Test
+    void positionOnlyObserverIsSensorValidWhenTicksRead() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 100.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertTrue(Double.isNaN(snapshot.acceleration()));
+        assertTrue(snapshot.sensorValid());
+    }
+
+    @Test
+    void analogMappedAsTicksWithoutVelocityIsSensorValid() {
+        RevAnalogSensorObserver analog = new RevAnalogSensorObserver("pot", () -> 100.0, "mm");
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> analog.read(0L).value())
+                .build()
+                .capture();
+        assertEquals(100.0, snapshot.position(), 1e-9);
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertTrue(snapshot.sensorValid());
+    }
+
+    @Test
+    void missingRequiredPositionStillInvalidatesWithoutVelocity() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "arm",
+                        () -> 10L,
+                        MechanismUnits.rotaryRadians("arm", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> Double.NaN)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.MISSING, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+    }
+
+    @Test
+    void unsupportedPositionKeepsSensorValidFalse() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "pot",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("pot", 1.0, DirectionSign.POSITIVE))
+                .absoluteSensor(() -> 12.5, "mm")
+                .ticksPerSecond(() -> 0.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.VALID, snapshot.absoluteSensor().validity());
+        assertFalse(snapshot.sensorValid());
+    }
+
+    @Test
+    void wiredMissingVelocityStillClearsSensorValid() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 100.0)
+                .ticksPerSecond(() -> Double.NaN)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.MISSING, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+    }
+
+    @Test
+    void wiredStaleVelocityStillClearsSensorValid() {
+        AtomicLong time = new AtomicLong(1_000_000L);
+        MechanismObserver observer = livenessObserver(time, 50_000_000L);
+        observer.capture();
+        time.addAndGet(50_000_001L);
+        MechanismSnapshot snapshot = observer.capture();
+        assertEquals(MeasurementValidity.STALE, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+    }
+
+    @Test
+    void wiredThrowingVelocityStillClearsSensorValid() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 0L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 100.0)
+                .ticksPerSecond(() -> {
+                    throw new IllegalStateException("disconnected velocity");
+                })
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.MISSING, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+    }
+
+    @Test
+    void positionOnlyDisagreementStillClearsSensorValid() {
+        AtomicReference<Double> primary = new AtomicReference<>(100.0);
+        AtomicReference<Double> redundant = new AtomicReference<>(160.0);
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 1_000L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(primary::get)
+                .redundantTicks(redundant::get)
+                .disagreementThreshold(10.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+        assertEquals(MeasurementValidity.DISAGREEING,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
     }
 
     private static void assertPrimaryChannels(MechanismSnapshot snapshot, MeasurementValidity expected) {

--- a/src/test/java/org/allsparks/mimic/observe/SnapshotValidatorTest.java
+++ b/src/test/java/org/allsparks/mimic/observe/SnapshotValidatorTest.java
@@ -63,6 +63,7 @@ class SnapshotValidatorTest {
         assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.positionSample().validity());
         assertEquals(MeasurementValidity.UNSUPPORTED,
                 SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+        assertFalse(snapshot.sensorValid());
         assertFalse(SnapshotValidator.hasUsablePosition(snapshot));
     }
 
@@ -98,6 +99,24 @@ class SnapshotValidatorTest {
                 .capture();
         assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
         assertEquals(MeasurementValidity.DISAGREEING,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+    }
+
+    @Test
+    void classifyPositionDoesNotTreatMissingVelocityAsDisagreement() {
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 1_000L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(() -> 100.0)
+                .ticksPerSecond(() -> Double.NaN)
+                .redundantTicks(() -> 100.0)
+                .disagreementThreshold(10.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.MISSING, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+        assertEquals(MeasurementValidity.VALID,
                 SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
     }
 
@@ -138,16 +157,37 @@ class SnapshotValidatorTest {
     }
 
     @Test
+    void classifyPositionReportsDisagreeingWhenPositionOnlyRedundantOffset() {
+        AtomicReference<Double> primary = new AtomicReference<>(100.0);
+        AtomicReference<Double> redundant = new AtomicReference<>(160.0);
+        MechanismSnapshot snapshot = MechanismObserver.builder(
+                        "elev",
+                        () -> 1_000L,
+                        MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
+                .ticks(primary::get)
+                .redundantTicks(redundant::get)
+                .disagreementThreshold(10.0)
+                .build()
+                .capture();
+        assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertFalse(snapshot.sensorValid());
+        assertEquals(MeasurementValidity.DISAGREEING,
+                SnapshotValidator.classifyPosition(snapshot, -1000.0, 1000.0));
+    }
+
+    @Test
     void hasUsablePositionFollowsPositionSampleNotAggregateSensorValid() {
         MechanismSnapshot snapshot = MechanismObserver.builder(
                         "elev",
                         () -> 0L,
                         MechanismUnits.linearMillimeters("elev", 1.0, DirectionSign.POSITIVE))
                 .ticks(() -> 100.0)
+                .ticksPerSecond(() -> Double.NaN)
                 .build()
                 .capture();
         assertEquals(MeasurementValidity.VALID, snapshot.positionSample().validity());
-        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.velocitySample().validity());
+        assertEquals(MeasurementValidity.MISSING, snapshot.velocitySample().validity());
         assertFalse(snapshot.sensorValid());
         assertTrue(SnapshotValidator.hasUsablePosition(snapshot));
         assertEquals(MeasurementValidity.VALID,


### PR DESCRIPTION
## Summary

Stop treating omitted velocity as a failed observation. `sensorValid` now follows wired required channels: usable primary pose, optional `UNSUPPORTED` velocity, and no encoder disagreement.

## Problem

`sensorValid` required usable velocity. Position-only and analog-as-ticks observers were always invalid, including potentiometer mechanisms.

## Solution

```text
sensorValid = position usable
    && (velocity UNSUPPORTED || velocity usable)
    && not disagreeing
```

Analog-only wires the mapped analog value as `ticks` and omits `ticksPerSecond`. Omitted ticks still keeps `sensorValid` false. `absoluteSensor` is not a substitute primary pose.

`classifyPosition` reports `DISAGREEING` for position-only redundant offset without requiring usable velocity. Wired `MISSING`/`STALE` velocity is not classified as disagreement.

## Scope

Issue #27 boolean, tests, Javadoc, architecture/troubleshooting/glossary, audit C2 note.

## Out of scope

- #28 missing limit log validity
- Inferring velocity from position
- Actuation / hardware
- Dependabot upgrades

## Architecture impact

Aggregate validity means “configured required channels,” not “every possible channel exists.” Per-channel `SensorSample` validity is unchanged.

## Safety impact

No motor or servo writes. Missing/stale/throwing wired velocity still invalidates.

## Compatibility impact

Callers that treated velocity-less snapshots as invalid will now see `sensorValid == true` when pose is usable. That is the intended behavior.

## Tests

Position-only valid; analog-as-ticks valid; missing/unsupported position still invalid; wired missing/stale/throwing velocity still invalid; position-only disagreement; `hasUsablePosition` independence via wired-but-missing velocity.

## Validation results

Local Gradle daemons were contended; GitHub Actions CI is the confirmation gate.

## Hardware validation

Not performed. Not required.

## Documentation

Observer/snapshot Javadoc; architecture; troubleshooting; glossary; CHANGELOG; audit C2; priority ledger.

## Risks

Students may assume analog-only via `absoluteSensor` is a valid snapshot. Docs state analog-only uses `ticks`.

## Rollback or disable strategy

Revert this PR. Previous conjunction (velocity always required) returns.

## Known limitations

Limit CSV validity remains #28. Hub observation remains #6.

## Related issue

Closes #27
Part of #24
