### PR TITLE
Export missing limit-switch validity instead of asserted=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Initial public repository scaffold for The Allsparks FTC Team 36117.
 - Phase 0 `STALE` is documented and tested as observer liveness (gap since the previous `capture()` start), not Control Hub sample age. `staleAfterNanos <= 0` remains the default off switch ([#25](https://github.com/The-Allsparks/MIMIC/issues/25)).
 - `MechanismSnapshot` preserves position and velocity `SensorSample` validity so `STALE` is distinguishable from `MISSING` / `UNSUPPORTED`. Observation logs keep `pos` / `vel` and add `posValid` / `velValid` ([#26](https://github.com/The-Allsparks/MIMIC/issues/26)).
+- Observation logs keep `lower` / `upper` and add `lowerValid` / `upperValid`. Unusable limit asserted state exports as `n/a` so a disconnected switch is not graphed as not-at-limit ([#28](https://github.com/The-Allsparks/MIMIC/issues/28)).
 - Source-backed mechanism-control research, build-versus-adopt decision, architecture, phased roadmap, and student documentation.
 - CI for compile, unit tests, and relative documentation link checks.
 

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -6,9 +6,9 @@ Living work-order for the orchestrator. Update after each issue or pull request.
 |-------|--------|
 | **Updated** | 2026-08-17 |
 | **Audited SHA** | `5847806f094f846cb3e8a4adf7ad0b355c4034fb` |
-| **Current implementation stream** | `feature/issue-27-sensor-valid` from `main` (`ae2f17e`; PR #40 / #26 merged) |
+| **Current implementation stream** | `feature/issue-28-limit-validity-log` from `main` (`3dd761f`; PR #41 / #27 merged) |
 | **Automatic merge** | **false** — human approval required |
-| **Active subagent** | implementing #27 |
+| **Active subagent** | implementing #28 |
 | **Hardware available** | no (elevator not selected) |
 
 Full findings: [initial-deep-audit.md](initial-deep-audit.md). Roadmap: [#24](https://github.com/The-Allsparks/MIMIC/issues/24).
@@ -41,8 +41,8 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 | #7 Fake hardware | Foundation | Implemented in PR #1 | #5 | Open | — | same | #1 | Green | Pending #1 | Close on merge of #1 | Commented |
 | [#25](https://github.com/The-Allsparks/MIMIC/issues/25) Stale classification | HIGH correctness | Implemented locally | Phase 0 observer (PR #1) | Observer-liveness docs + tests on PR #1 | ended after implement | `feature/phase-0-scaffold` | #1 | Pending push | Not authorized | None | Push; wait for CI; human merge |
 | [#26](https://github.com/The-Allsparks/MIMIC/issues/26) Snapshot validity | MEDIUM architecture | Done | #25 closed | Merged on `main` via [PR #40](https://github.com/The-Allsparks/MIMIC/pull/40) (`ae2f17e`) | — | `feature/issue-26-snapshot-validity` | [#40](https://github.com/The-Allsparks/MIMIC/pull/40) | Green | Merged | None | Closed with #40 |
-| [#27](https://github.com/The-Allsparks/MIMIC/issues/27) sensorValid velocity | MEDIUM correctness | Implemented locally | #26 merged | Position-only `sensorValid`; `UNSUPPORTED` velocity does not clear; analog-as-`ticks`; `classifyPosition` disagreement without requiring usable velocity | — | `feature/issue-27-sensor-valid` | — | — | Not authorized | None | Orchestrator commit; open PR to `main` |
-| [#28](https://github.com/The-Allsparks/MIMIC/issues/28) Missing limit logs | MEDIUM correctness | Ready | logger | Not started | — | — | — | — | — | None | After #25 |
+| [#27](https://github.com/The-Allsparks/MIMIC/issues/27) sensorValid velocity | MEDIUM correctness | Done | #26 merged | Merged on `main` via [PR #41](https://github.com/The-Allsparks/MIMIC/pull/41) (`3dd761f`) | — | `feature/issue-27-sensor-valid` | [#41](https://github.com/The-Allsparks/MIMIC/pull/41) | Green | Merged | None | Closed with #41 |
+| [#28](https://github.com/The-Allsparks/MIMIC/issues/28) Missing limit logs | MEDIUM correctness | Implemented locally | logger | Observation export adds `lowerValid` / `upperValid`; unusable `lower` / `upper` is `n/a`. `#29`/`#30`/`#32` not included. | — | `feature/issue-28-limit-validity-log` | — | — | Not authorized | None | Orchestrator commit; open PR to `main` |
 | [#29](https://github.com/The-Allsparks/MIMIC/issues/29) Phase 1 flag honesty | MEDIUM usability | Ready (Javadoc now) | #6 for full telemetry | Not started | — | — | — | — | — | Full Phase 1 needs hardware | After #25 |
 | [#30](https://github.com/The-Allsparks/MIMIC/issues/30) Pin Actions SHAs | MEDIUM security | Ready | — | Not started | — | — | — | — | — | None | After correctness slices |
 | [#31](https://github.com/The-Allsparks/MIMIC/issues/31) Branch protection | HIGH security | Human decision | Reviewer policy | Not started | — | — | — | — | — | Maintainer policy | Request decision |
@@ -56,11 +56,11 @@ An issue is **ready** only when requirements are clear, dependencies are resolve
 
 | Field | Value |
 |-------|--------|
-| **Selected** | [#27](https://github.com/The-Allsparks/MIMIC/issues/27) — Do not require unused velocity for `sensorValid` |
-| **Status** | Implemented locally on `feature/issue-27-sensor-valid`. Not committed by the implementer. `#28` not included. |
-| **Why highest priority** | C2 correctness: position-only / analog observers must not look permanently failed. `#26` merged so per-channel validity is on the snapshot. |
-| **Dependencies** | `#26` merged; `main` at `ae2f17e` |
-| **Expected deliverable** | `sensorValid` = usable pose and (`UNSUPPORTED` or usable velocity) and not disagreeing; analog-as-`ticks`; tests; docs |
+| **Selected** | [#28](https://github.com/The-Allsparks/MIMIC/issues/28) — Export missing limit-switch validity instead of asserted=false |
+| **Status** | Implemented locally on `feature/issue-28-limit-validity-log`. Not committed by the implementer. `#29`/`#30`/`#32` not included. |
+| **Why highest priority** | C3 correctness: CSV must not teach that a disconnected limit is “not at limit.” `#27` merged so `main` is `3dd761f`. |
+| **Dependencies** | `#27` merged; `main` at `3dd761f` |
+| **Expected deliverable** | Additive `lowerValid` / `upperValid`; unusable asserted exports as `n/a`; tests; docs |
 | **Expected validation** | `./gradlew check` (local); CI on a new PR to `main` after orchestrator commit |
 | **Hardware required** | No |
 

--- a/docs/mechanism-control/testing.md
+++ b/docs/mechanism-control/testing.md
@@ -38,4 +38,5 @@ Each card requires: adult supervision, supports/restraints, exclusion zone, e-st
 2. Export CSV from `MimicEventLogger` in a unit test.
 3. Graph `pos` vs time and mark a `SENSOR_INVALID` row.
 4. From `MechanismObserverTest.gapAboveThresholdMarksNumericSamplesStale`, explain why `STALE` is observer liveness (a slow `capture()` gap), not a frozen Hub encoder. Mark a CSV row with `posValid=STALE` versus `MISSING`.
-5. Explain why `NO_ACTIVE_CONTROL` is the correct Phase 0 goal result.
+5. From `MimicSessionTest.disconnectedLimitSwitchIsMissing`, mark a CSV row with `lowerValid=MISSING` and `lower=n/a`. Contrast that with a healthy `lower=false` that also has `lowerValid=VALID`.
+6. Explain why `NO_ACTIVE_CONTROL` is the correct Phase 0 goal result.

--- a/src/main/java/org/allsparks/mimic/log/MimicEventLogger.java
+++ b/src/main/java/org/allsparks/mimic/log/MimicEventLogger.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import org.allsparks.mimic.observe.LimitSwitchSample;
 import org.allsparks.mimic.observe.MechanismSnapshot;
 
 /**
@@ -14,7 +15,9 @@ import org.allsparks.mimic.observe.MechanismSnapshot;
  * Does not command hardware. Field names are TRACE-compatible (stable keys).
  * Observation export keeps {@code pos} / {@code vel} and additively includes
  * {@code posValid} / {@code velValid} as {@link org.allsparks.mimic.observe.MeasurementValidity}
- * enum names.
+ * enum names. Limit channels keep {@code lower} / {@code upper} and add
+ * {@code lowerValid} / {@code upperValid} the same way; unusable asserted
+ * state is exported as {@code n/a} instead of a naked {@code false}.
  */
 public final class MimicEventLogger {
     private final int capacity;
@@ -51,8 +54,10 @@ public final class MimicEventLogger {
         fields.put("reqOut", format(snapshot.requestedOutput()));
         fields.put("appOut", format(snapshot.appliedOutput()));
         fields.put("amps", format(snapshot.currentAmps()));
-        fields.put("lower", Boolean.toString(snapshot.lowerLimit().asserted()));
-        fields.put("upper", Boolean.toString(snapshot.upperLimit().asserted()));
+        fields.put("lower", formatAsserted(snapshot.lowerLimit()));
+        fields.put("lowerValid", snapshot.lowerLimit().validity().name());
+        fields.put("upper", formatAsserted(snapshot.upperLimit()));
+        fields.put("upperValid", snapshot.upperLimit().validity().name());
         fields.put("sensorValid", Boolean.toString(snapshot.sensorValid()));
         fields.put("disagree", format(snapshot.disagreement()));
         fields.put("loopNs", Long.toString(snapshot.loopDurationNanos()));
@@ -87,5 +92,12 @@ public final class MimicEventLogger {
             return "NaN";
         }
         return String.format(Locale.US, "%.4f", value);
+    }
+
+    private static String formatAsserted(LimitSwitchSample sample) {
+        if (!sample.isUsable()) {
+            return "n/a";
+        }
+        return Boolean.toString(sample.asserted());
     }
 }

--- a/src/test/java/org/allsparks/mimic/MimicSessionTest.java
+++ b/src/test/java/org/allsparks/mimic/MimicSessionTest.java
@@ -14,6 +14,7 @@ import org.allsparks.mimic.log.MimicEvent;
 import org.allsparks.mimic.log.MimicEventLogger;
 import org.allsparks.mimic.log.MimicEventType;
 import org.allsparks.mimic.observe.MeasurementValidity;
+import org.allsparks.mimic.observe.MechanismObserver;
 import org.allsparks.mimic.observe.MechanismSnapshot;
 import org.allsparks.mimic.units.DirectionSign;
 import org.allsparks.mimic.units.MechanismUnits;
@@ -67,6 +68,16 @@ class MimicSessionTest {
         assertTrue(session.logger().exportCsv().contains("pos="));
         assertTrue(session.logger().exportCsv().contains("posValid=VALID"));
         assertTrue(session.logger().exportCsv().contains("velValid=VALID"));
+        MimicEvent observation = observationEvent(session);
+        assertEquals("true", observation.fields().get("lower"));
+        assertEquals("VALID", observation.fields().get("lowerValid"));
+        assertEquals("false", observation.fields().get("upper"));
+        assertEquals("VALID", observation.fields().get("upperValid"));
+        String csv = session.logger().exportCsv();
+        assertTrue(csv.contains("lower=true"));
+        assertTrue(csv.contains("lowerValid=VALID"));
+        assertTrue(csv.contains("upper=false"));
+        assertTrue(csv.contains("upperValid=VALID"));
     }
 
     @Test
@@ -87,9 +98,43 @@ class MimicSessionTest {
         AtomicLong time = new AtomicLong(0L);
         FakeMechanismHardware hardware = hardware(time);
         hardware.lowerLimit().disconnect();
-        MechanismSnapshot snapshot = MimicSession.create(hardware.observer()).observe();
+        MimicSession session = MimicSession.create(hardware.observer());
+        MechanismSnapshot snapshot = session.observe();
         assertEquals(MeasurementValidity.MISSING, snapshot.lowerLimit().validity());
         assertFalse(snapshot.lowerLimit().asserted());
+        MimicEvent observation = observationEvent(session);
+        assertEquals("n/a", observation.fields().get("lower"));
+        assertEquals("MISSING", observation.fields().get("lowerValid"));
+        String csv = session.logger().exportCsv();
+        assertTrue(csv.contains("lowerValid=MISSING"));
+        assertTrue(csv.contains("lower=n/a"));
+        assertFalse(csv.contains("lower=false"));
+    }
+
+    @Test
+    void omittedLimitSwitchExportsUnsupported() {
+        AtomicLong time = new AtomicLong(0L);
+        MechanismObserver observer = MechanismObserver.builder(
+                        "elev",
+                        time::get,
+                        MechanismUnits.linearMillimeters("elev", 10.0, DirectionSign.POSITIVE))
+                .ticks(() -> 0.0)
+                .ticksPerSecond(() -> 0.0)
+                .build();
+        MimicSession session = MimicSession.create(observer);
+        MechanismSnapshot snapshot = session.observe();
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.lowerLimit().validity());
+        assertEquals(MeasurementValidity.UNSUPPORTED, snapshot.upperLimit().validity());
+        MimicEvent observation = observationEvent(session);
+        assertEquals("n/a", observation.fields().get("lower"));
+        assertEquals("UNSUPPORTED", observation.fields().get("lowerValid"));
+        assertEquals("n/a", observation.fields().get("upper"));
+        assertEquals("UNSUPPORTED", observation.fields().get("upperValid"));
+        String csv = session.logger().exportCsv();
+        assertTrue(csv.contains("lowerValid=UNSUPPORTED"));
+        assertTrue(csv.contains("upperValid=UNSUPPORTED"));
+        assertTrue(csv.contains("lower=n/a"));
+        assertTrue(csv.contains("upper=n/a"));
     }
 
     @Test
@@ -151,5 +196,14 @@ class MimicSessionTest {
                 "elev",
                 time::get,
                 MechanismUnits.linearMillimeters("elev", 10.0, DirectionSign.POSITIVE));
+    }
+
+    private static MimicEvent observationEvent(MimicSession session) {
+        for (MimicEvent event : session.logger().snapshot()) {
+            if ("observation".equals(event.message())) {
+                return event;
+            }
+        }
+        throw new AssertionError("missing observation event");
     }
 }


### PR DESCRIPTION
## Summary

Observation logs no longer present a missing or unsupported limit switch as `lower=false` / `upper=false`. Additive `lowerValid` / `upperValid` keys carry `MeasurementValidity` names, and unusable asserted state exports as `n/a`.

## Problem

`LimitSwitchSample.missing()` stores `asserted=false`, and the logger exported that boolean. Students graphing CSV concluded the carriage was not at a limit when the switch was missing.

## Solution

Keep `lower` / `upper`. Add `lowerValid` / `upperValid`. When the sample is not usable, export asserted as `n/a`. In-memory `asserted()` for missing samples remains `false`. Invert mapping for VALID reads is unchanged.

## Scope

Issue #28 logger export, tests, changelog, testing.md exercise.

## Out of scope

- Treating missing as electrically asserted (NC-open)
- #29 Phase 1 flag honesty
- #30 Action SHA pins
- Actuation / hardware

## Architecture impact

Log field set is additive. Old keys remain.

## Safety impact

No motor or servo writes. Missing is no longer logged as a trusted "clear of the switch."

## Compatibility impact

Parsers that only read `lower=false` will see `lower=n/a` for missing/unsupported channels. Healthy not-asserted stays `lower=false` with `lowerValid=VALID`.

## Tests

`MimicSessionTest`: healthy asserted lower; disconnected switch; omitted limits. Local `.\gradlew.bat check` BUILD SUCCESSFUL (1m 2s).

## Validation results

Desktop `./gradlew check` passed. CI on this PR is the second gate.

## Hardware validation

Not performed. Not required.

## Documentation

Logger Javadoc, CHANGELOG, testing.md student step, priority ledger.

## Risks

CSV consumers that assumed `lower` was always `true`/`false` must accept `n/a`.

## Rollback or disable strategy

Revert this PR.

## Known limitations

Electrical NC-open without a throw still looks like a boolean from the SDK. Hub observation remains #6.

## Related issue

Closes #28
Part of #24
